### PR TITLE
Avoid duplicate memory connections

### DIFF
--- a/tests/test_memory_system.py
+++ b/tests/test_memory_system.py
@@ -1,0 +1,17 @@
+import sys, os
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'verdant-lite')))
+from core.MemorySystem import MemorySystem
+
+
+def test_connect_thoughts_avoids_duplicates_and_updates_weight():
+    m = MemorySystem()
+    m.add_thought('A', stability=0.5)
+    m.add_thought('B', stability=0.5)
+    # initial link from add_thought('B')
+    m.connect_thoughts('A', 'B', weight=0.9)
+    m.connect_thoughts('A', 'B', weight=0.8)
+    connections = [c for c in m.memory_store['A']['connections'] if c[0] == 'B']
+    assert len(connections) == 1
+    assert connections[0][1] == 0.8

--- a/verdant-lite/core/MemorySystem.py
+++ b/verdant-lite/core/MemorySystem.py
@@ -28,10 +28,33 @@ class MemorySystem:
                     self.connect_thoughts(new_label, thought)
 
     def connect_thoughts(self, label1, label2, weight=None):
+        """Create or update a weighted link between two thoughts.
+
+        Prevents duplicate connection entries within ``memory_store`` by
+        updating the weight if the connection already exists. This keeps the
+        cognitive graph consistent with the underlying NetworkX structure.
+        """
+
+        if label1 not in self.memory_store or label2 not in self.memory_store:
+            raise KeyError("Both thoughts must exist before they can be connected.")
+
         if weight is None:
-            weight = self.memory_store[label1]["stability"] * self.memory_store[label2]["stability"]
-        self.memory_store[label1]["connections"].append((label2, weight))
-        self.memory_store[label2]["connections"].append((label1, weight))
+            weight = (
+                self.memory_store[label1]["stability"]
+                * self.memory_store[label2]["stability"]
+            )
+
+        def update_connection(src, dst):
+            connections = self.memory_store[src]["connections"]
+            for idx, (label, _) in enumerate(connections):
+                if label == dst:
+                    connections[idx] = (dst, weight)
+                    break
+            else:
+                connections.append((dst, weight))
+
+        update_connection(label1, label2)
+        update_connection(label2, label1)
         self.graph.add_edge(label1, label2, weight=weight)
 
     def retrieve_related_thoughts(self, label):


### PR DESCRIPTION
## Summary
- ensure `connect_thoughts` validates nodes and updates existing links instead of duplicating them
- add regression test for stable, single connection weights

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897e4a290308325981e0fc8aa6c189d